### PR TITLE
Added ability to get APIs from scratch based on version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/*
+.settings/*
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -1,97 +1,98 @@
-<!--
-  ~ The contents of this file are subject to the terms of the Common Development and
-  ~  Distribution License (the License). You may not use this file except in compliance with the
-  ~  License.
-  ~
-  ~  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
-  ~  specific language governing permission and limitations under the License.
-  ~
-  ~  When distributing Covered Software, include this CDDL Header Notice in each file and include
-  ~  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
-  ~  Header, with the fields enclosed by brackets [] replaced by your own identifying
-  ~  information: "Portions copyright [year] [name of copyright owner]".
-  ~
-  ~  Copyright 2017 ForgeRock AS.
-  ~
-  -->
+<!-- ~ The contents of this file are subject to the terms of the Common Development 
+	and ~ Distribution License (the License). You may not use this file except 
+	in compliance with the ~ License. ~ ~ You can obtain a copy of the License 
+	at https://forgerock.org/cddlv1-0/. See the License for the ~ specific language 
+	governing permission and limitations under the License. ~ ~ When distributing 
+	Covered Software, include this CDDL Header Notice in each file and include 
+	~ the License file at legal/CDDLv1.0.txt. If applicable, add the following 
+	below the CDDL ~ Header, with the fields enclosed by brackets [] replaced 
+	by your own identifying ~ information: "Portions copyright [year] [name of 
+	copyright owner]". ~ ~ Copyright 2017 ForgeRock AS. ~ -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>uk.org.openbanking</groupId>
-    <artifactId>openbanking-sdk</artifactId>
-    <packaging>jar</packaging>
-    <version>1.1.0.3-SNAPSHOT</version>
-    <name>openbanking-sdk</name>
+	<groupId>uk.org.openbanking</groupId>
+	<artifactId>openbanking-sdk</artifactId>
+	<packaging>jar</packaging>
+	<version>1.1.0.3-SNAPSHOT</version>
+	<name>openbanking-sdk</name>
 
-    <properties>
-        <jersey.version>2.25.1</jersey.version>
-        <jwt.nimbus.version>4.16.2</jwt.nimbus.version>
-        <springfox-version>2.6.1</springfox-version>
-    </properties>
+	<properties>
+		<jersey.version>2.25.1</jersey.version>
+		<jwt.nimbus.version>4.16.2</jwt.nimbus.version>
+		<springfox-version>2.6.1</springfox-version>
+	</properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.glassfish.jersey</groupId>
-                <artifactId>jersey-bom</artifactId>
-                <version>${jersey.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.glassfish.jersey</groupId>
+				<artifactId>jersey-bom</artifactId>
+				<version>${jersey.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-            <version>${jwt.nimbus.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.8.9</version>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-            <version>${springfox-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
-            <version>${springfox-version}</version>
-        </dependency>
-        <!-- Bean Validation API support -->
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>1.1.0.Final</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.9</version>
-        </dependency>
-    </dependencies>
+	<dependencies>
+		<dependency>
+			<groupId>com.nimbusds</groupId>
+			<artifactId>nimbus-jose-jwt</artifactId>
+			<version>${jwt.nimbus.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.8.9</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>${springfox-version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>${springfox-version}</version>
+		</dependency>
+		<!-- Bean Validation API support -->
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+			<version>1.1.0.Final</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.9.9</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.2</version>
+		</dependency>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
-                <inherited>true</inherited>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
+	</dependencies>
 
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
+				<inherited>true</inherited>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+
+	</build>
 </project>

--- a/src/main/java/uk/org/openbanking/OBHeaders.java
+++ b/src/main/java/uk/org/openbanking/OBHeaders.java
@@ -42,7 +42,7 @@ public class OBHeaders {
     /**
      * An RFC4122 UID used as a correlation id.
      *
-     * If provided, the ASPSP must “play back” this value in the x-fapi-interaction-id response header.
+     * If provided, the ASPSP must "play back" this value in the x-fapi-interaction-id response header.
      */
     public static final String X_FAPI_INTERACTION_ID = "x-fapi-interaction-id";
 

--- a/src/main/java/uk/org/openbanking/OBJoseHeaderClaims.java
+++ b/src/main/java/uk/org/openbanking/OBJoseHeaderClaims.java
@@ -38,7 +38,7 @@ public class OBJoseHeaderClaims {
      *
      * This indicates that the message payload is not base64 url encoded.
      *
-     * (See RFC 7797 – The “b64” header Parameter)
+     * (See RFC 7797 – The "b64" header Parameter)
      */
     public static final String B64 = "b64";
 
@@ -46,7 +46,7 @@ public class OBJoseHeaderClaims {
      * This must be a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC
      * until the date/time.
      *
-     * This is a private header parameter name. (See RFC 7515 – Private Header Parameter Names)
+     * This is a private header parameter name. (See RFC 7515 - Private Header Parameter Names)
      */
     public static final String OB_IAT = "http://openbanking.org.uk/iat";
 
@@ -59,8 +59,8 @@ public class OBJoseHeaderClaims {
 
     /**
      *
-     * This must be a string array consisting of the values “b64”, “http://openbanking.org.uk/iat“,
-     * “http://openbanking.org.uk/iss“
+     * This must be a string array consisting of the values "b64", "http://openbanking.org.uk/iat",
+     * "http://openbanking.org.uk/iss"
      *
      * This indicates that the JWS signature validator must understand and process the three additional claims.
      */

--- a/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscovery.java
+++ b/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscovery.java
@@ -57,7 +57,7 @@ public class OBDiscovery {
 
     public Optional<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> getPaymentInitiationAPI(String version) {
     	Optional<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> result = paymentInitiationAPIs.stream().filter(apis -> apis.getVersion().equals(version)).findFirst();
-    	if (result==null) {
+    	if (!result.isPresent()) {
     		OBDiscoveryAPILinksPayment obdapilp = new OBDiscoveryAPILinksPayment();
     		OBDiscoveryAPI<OBDiscoveryAPILinksPayment> obDiscoveryAPILinksPayment = new OBDiscoveryAPI<OBDiscoveryAPILinksPayment>();
     		obDiscoveryAPILinksPayment.setVersion(version);
@@ -97,7 +97,6 @@ public class OBDiscovery {
     		this.addAccountAndTransactionAPI(obDiscoveryAPILinksAccount);
     		result = Optional.of(obDiscoveryAPILinksAccount);
     	}
-    	System.out.println(result);
         return result;
     }
 

--- a/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscovery.java
+++ b/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscovery.java
@@ -32,10 +32,10 @@ import java.util.Optional;
 public class OBDiscovery {
 
     @JsonProperty("PaymentInitiationAPI")
-    private List<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> paymentInitiationAPIs;
+    private List<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> paymentInitiationAPIs = new ArrayList<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>>();
 
     @JsonProperty("AccountAndTransactionAPI")
-    private List<OBDiscoveryAPI<OBDiscoveryAPILinksAccount>> accountAndTransactionAPIs;
+    private List<OBDiscoveryAPI<OBDiscoveryAPILinksAccount>> accountAndTransactionAPIs = new ArrayList<OBDiscoveryAPI<OBDiscoveryAPILinksAccount>>();
 
     public OBDiscovery paymentInitiationAPI(List<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> paymentInitiationAPIs) {
         this.paymentInitiationAPIs = paymentInitiationAPIs;
@@ -43,9 +43,6 @@ public class OBDiscovery {
     }
 
     public OBDiscovery addPaymentInitiationAPI(OBDiscoveryAPI<OBDiscoveryAPILinksPayment> paymentInitiationAPI) {
-        if (this.paymentInitiationAPIs == null) {
-            this.paymentInitiationAPIs = new ArrayList<>();
-        }
         this.paymentInitiationAPIs.add(paymentInitiationAPI);
         return this;
     }
@@ -59,7 +56,16 @@ public class OBDiscovery {
     }
 
     public Optional<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> getPaymentInitiationAPI(String version) {
-        return paymentInitiationAPIs.stream().filter(apis -> apis.getVersion().equals(version)).findFirst();
+    	Optional<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> result = paymentInitiationAPIs.stream().filter(apis -> apis.getVersion().equals(version)).findFirst();
+    	if (result==null) {
+    		OBDiscoveryAPILinksPayment obdapilp = new OBDiscoveryAPILinksPayment();
+    		OBDiscoveryAPI<OBDiscoveryAPILinksPayment> obDiscoveryAPILinksPayment = new OBDiscoveryAPI<OBDiscoveryAPILinksPayment>();
+    		obDiscoveryAPILinksPayment.setVersion(version);
+    		obDiscoveryAPILinksPayment.setLinks(obdapilp);
+    		this.addPaymentInitiationAPI(obDiscoveryAPILinksPayment);
+    		result = Optional.of(obDiscoveryAPILinksPayment);
+    	}
+        return result;
     }
 
     public OBDiscovery accountAndTransactionAPIs(List<OBDiscoveryAPI<OBDiscoveryAPILinksAccount>> accountAndTransactionAPIs) {
@@ -68,9 +74,6 @@ public class OBDiscovery {
     }
 
     public OBDiscovery addAccountAndTransactionAPI(OBDiscoveryAPI<OBDiscoveryAPILinksAccount> accountAndTransactionAPI) {
-        if (this.accountAndTransactionAPIs == null) {
-            this.accountAndTransactionAPIs = new ArrayList<>();
-        }
         this.accountAndTransactionAPIs.add(accountAndTransactionAPI);
         return this;
     }
@@ -84,7 +87,18 @@ public class OBDiscovery {
     }
 
     public Optional<OBDiscoveryAPI<OBDiscoveryAPILinksAccount>> getAccountAndTransactionAPI(String version) {
-        return accountAndTransactionAPIs.stream().filter(apis -> apis.getVersion().equals(version)).findFirst();
+    	
+    	Optional<OBDiscoveryAPI<OBDiscoveryAPILinksAccount>> result = accountAndTransactionAPIs.stream().filter(apis -> apis.getVersion().equals(version)).findFirst();
+    	if (!result.isPresent()) {
+    		OBDiscoveryAPILinksAccount obdapilp = new OBDiscoveryAPILinksAccount();
+    		OBDiscoveryAPI<OBDiscoveryAPILinksAccount> obDiscoveryAPILinksAccount = new OBDiscoveryAPI<OBDiscoveryAPILinksAccount>();
+    		obDiscoveryAPILinksAccount.setVersion(version);
+    		obDiscoveryAPILinksAccount.setLinks(obdapilp);
+    		this.addAccountAndTransactionAPI(obDiscoveryAPILinksAccount);
+    		result = Optional.of(obDiscoveryAPILinksAccount);
+    	}
+    	System.out.println(result);
+        return result;
     }
 
     @Override

--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalAccountIdentification2Code.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalAccountIdentification2Code.java
@@ -21,11 +21,11 @@ public enum OBExternalAccountIdentification2Code {
     /**
      * An identifier used internationally by financial institutions to uniquely identify the account of a customer at
      * a financial institution, as described in the latest edition of the international standard ISO 13616. “Banking
-     * and related financial services – International Bank Account Number (IBAN)”.
+     * and related financial services - International Bank Account Number (IBAN)".
      */
     IBAN,
     /**
-     * Sort Code and Account Number – identifier scheme used in the UK by financial institutions to identify the
+     * Sort Code and Account Number - identifier scheme used in the UK by financial institutions to identify the
      * account of a customer. The identifier is the concatenation of the 6 digit UK sort code and 8 digit account number.
      The regular expression for this identifier is: ^[0-9]{6}[0-9]{8}$
      */


### PR DESCRIPTION
When building my Discovery API I found that I could not call 
```
Optional<OBDiscoveryAPI<OBDiscoveryAPILinksPayment>> obdalp = obDiscovery..getPaymentInitiationAPI(obOperation.getVersion());
```
since there was no values initialized. I have added basic initialization so that when a call is made and it is an empty List it will generate the necessary classes and add it the List.

This should not break anything.