### PR TITLE
Deploy artifact to bintray on master merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Maven
+target/
+
+# Intellij
+.idea/
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,15 @@
 language: java
 
+deploy:
+  - provider: script
+    script: bash release.sh
+    on:
+      branch: master
+
+cache:
+  directories:
+  - $HOME/.m2
+
+branches:
+  only:
+  - master

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
  *
  * Copyright 2017 ForgeRock AS.
 -->
+[![Build Status](https://travis-ci.org/ForgeRock/OpenBanking-Java-SDK.svg?branch=master)](https://travis-ci.org/ForgeRock/OpenBanking-Java-SDK)
 # OpenBanking-Java-SDK
 A Java SDK to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
   ~
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -91,7 +90,27 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <scmCommentPrefix>[ci skip]</scmCommentPrefix>
+                </configuration>
+            </plugin>
         </plugins>
-
     </build>
+
+    <scm>
+        <connection>scm:git:https://github.com/ForgeRock/OpenBanking-Java-SDK.git</connection>
+        <developerConnection>scm:git:https://github.com/ForgeRock/OpenBanking-Java-SDK.git</developerConnection>
+        <url>https://github.com/ForgeRock/OpenBanking-Java-SDK</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>bintray-repo</id>
+            <url>https://api.bintray.com/maven/benjefferies/forgerock/openbanking-sdk/;publish=1</url>
+        </repository>
+    </distributionManagement>
 </project>

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# This script will do a release of the artifact according to http://maven.apache.org/maven-release/maven-release-plugin/
+
+git config --global user.email "travis@travis-ci.org";
+git config --global user.name "Travis CI";
+mvn -s settings.xml -Dusername=$GITHUB_API_KEY release:prepare -B
+mvn -s settings.xml release:perform -Darguments="-Dmaven.javadoc.skip=true"

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>bintray-repo</id>
+            <username>benjefferies</username>
+            <password>${env.BINTRAY_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
Use travis builds to publish an artifact to bintray on every commit
to master. This will simplify the deployment process because it is
automatically deployed.

This change is a work in progress and depends on setting up a forgerock bintray account.

BINTRAY_PASSWORD is to be set in travis as an encrypted variable. This should be set to the API keep generated for the account