### PR TITLE
Checkout branch before releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@
         <connection>scm:git:https://github.com/ForgeRock/OpenBanking-Java-SDK.git</connection>
         <developerConnection>scm:git:https://github.com/ForgeRock/OpenBanking-Java-SDK.git</developerConnection>
         <url>https://github.com/ForgeRock/OpenBanking-Java-SDK</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <repository>

--- a/release.sh
+++ b/release.sh
@@ -2,6 +2,7 @@
 
 # This script will do a release of the artifact according to http://maven.apache.org/maven-release/maven-release-plugin/
 
+git checkout $TRAVIS_BRANCH
 git config --global user.email "travis@travis-ci.org";
 git config --global user.name "Travis CI";
 mvn -s settings.xml -Dusername=$GITHUB_API_KEY release:prepare -B


### PR DESCRIPTION
Travis will checkout a commit directly leaving it with a detached head.
This can be seen in the travis logs

```
0.49s$ git clone --depth=50 --branch=master https://github.com/ForgeRock/OpenBanking-Java-SDK.git ForgeRock/OpenBanking-Java-SDK
Cloning into 'ForgeRock/OpenBanking-Java-SDK'...
$ cd ForgeRock/OpenBanking-Java-SDK
$ git checkout -qf 248ca5726f809a8de13dc04b2b122aa9f42c7578
```

This causes an error

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project openbanking-sdk: An error is occurred in the checkin process: Exception while executing SCM command. Detecting the current branch failed: fatal: ref HEAD is not a symbolic ref -> [Help 1]
```

Checking out the actual branch should prevent this.