### PR TITLE
Change Maven repo to forgerock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <distributionManagement>
         <repository>
             <id>bintray-repo</id>
-            <url>https://api.bintray.com/maven/benjefferies/forgerock/openbanking-sdk/;publish=1</url>
+            <url>https://api.bintray.com/maven/forgerock/ORBI/OpenBanking-Java-SDK/;publish=1</url>
         </repository>
     </distributionManagement>
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -5,8 +5,8 @@
     <servers>
         <server>
             <id>bintray-repo</id>
-            <username>benjefferies</username>
-            <password>${env.BINTRAY_PASSWORD}</password>
+            <username>${env.BINTRAY_USERNAME}</username>
+            <password>${env.BINTRAY_API_KEY}</password>
         </server>
     </servers>
 </settings>


### PR DESCRIPTION
Previously we were pointing to a temporary repository to
prove the concept. Now artifacts are being published we can
change it to the forgerock bintray.