### PR TITLE
Auto generate license

### DIFF
--- a/legal/LICENSE.txt
+++ b/legal/LICENSE.txt
@@ -1,0 +1,13 @@
+The contents of this file are subject to the terms of the Common Development and
+Distribution License (the License). You may not use this file except in compliance with the
+License.
+
+You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+specific language governing permission and limitations under the License.
+
+When distributing Covered Software, include this CDDL Header Notice in each file and include
+the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+Header, with the fields enclosed by brackets [] replaced by your own identifying
+information: "Portions copyright [year] [name of copyright owner]".
+
+Copyright 2017 ForgeRock AS.

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,22 @@
 <!--
-  ~ The contents of this file are subject to the terms of the Common Development and
-  ~  Distribution License (the License). You may not use this file except in compliance with the
-  ~  License.
-  ~
-  ~  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
-  ~  specific language governing permission and limitations under the License.
-  ~
-  ~  When distributing Covered Software, include this CDDL Header Notice in each file and include
-  ~  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
-  ~  Header, with the fields enclosed by brackets [] replaced by your own identifying
-  ~  information: "Portions copyright [year] [name of copyright owner]".
-  ~
-  ~  Copyright 2017-2018 ForgeRock AS.
-  ~
-  -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    The contents of this file are subject to the terms of the Common Development and
+    Distribution License (the License). You may not use this file except in compliance with the
+    License.
+
+    You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+    specific language governing permission and limitations under the License.
+
+    When distributing Covered Software, include this CDDL Header Notice in each file and include
+    the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+    Header, with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions copyright [year] [name of copyright owner]".
+
+    Copyright 2017 ForgeRock AS.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -100,6 +101,31 @@
                 <configuration>
                     <scmCommentPrefix>[ci skip]</scmCommentPrefix>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <header>file://${project.basedir}/legal/LICENSE.txt</header>
+                    <excludes>
+                        <exclude>**/README</exclude>
+                        <exclude>**/*sh</exclude>
+                        <exclude>**/*txt</exclude>
+                        <exclude>settings.xml</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/main/resources/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>format</goal>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We generate the models from swagger specs. These swagger specs do not
come with the license prefix on the top. This plugin will automatically
add the license on a new build.