### PR TITLE
Add missing OBDiscoveryAPILinks subtypes

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
+++ b/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
@@ -29,6 +29,8 @@ import io.swagger.annotations.ApiModel;
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksAccount3.class, name = "OBDiscoveryAPILinksAccount3"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksPayment1.class, name = "OBDiscoveryAPILinksPayment1"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksPayment3.class, name = "OBDiscoveryAPILinksPayment3"),
+        @JsonSubTypes.Type(value = OBDiscoveryAPILinksFundsConfirmation3.class, name = "OBDiscoveryAPILinksFundsConfirmation3"),
+        @JsonSubTypes.Type(value = OBDiscoveryAPILinksEventNotification3.class, name = "OBDiscoveryAPILinksEventNotification3"),
 })
 @ApiModel(description = "Endpoints corresponding to a specific version")
 public interface OBDiscoveryAPILinks {


### PR DESCRIPTION
Without correctly subtyping we get the error

```
Caused by: org.springframework.web.client.RestClientException: Error while extracting response for type [class uk.org.openbanking.datamodel.discovery.OBDiscoveryResponse] and content type [application/json;charset=utf-8]; nested exception is org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Could not resolve type id 'OBDiscoveryAPILinksFundsConfirmation3' as a subtype of [simple type, class uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinks]: known type ids = [OBDiscoveryAPILinksAccount1, OBDiscoveryAPILinksAccount2, OBDiscoveryAPILinksAccount3, OBDiscoveryAPILinksPayment1, OBDiscoveryAPILinksPayment3] (for POJO property 'Links'); nested exception is com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'OBDiscoveryAPILinksFundsConfirmation3' as a subtype of [simple type, class uk.org.openbanking.datamodel.discovery.OBDiscoveryAPILinks]: known type ids = [OBDiscoveryAPILinksAccount1, OBDiscoveryAPILinksAccount2, OBDiscoveryAPILinksAccount3, OBDiscoveryAPILinksPayment1, OBDiscoveryAPILinksPayment3] (for POJO property 'Links')
 at [Source: (PushbackInputStream); line: 1, column: 13450] (through
reference chain:
uk.org.openbanking.datamodel.discovery.OBDiscoveryResponse["Data"]->uk.org.openbanking.datamodel.discovery.OBDiscovery["FundsConfirmationAPI"]->java.util.ArrayList[0]->uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI["Links"])
```