### PR TITLE
Change field names to lowercase

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/account/OBProduct2.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBProduct2.java
@@ -54,10 +54,10 @@ public class OBProduct2   {
   private OBOtherProductType1 otherProductType = null;
 
   @JsonProperty("BCA")
-  private OBBCAData1 BCA = null;
+  private OBBCAData1 bca = null;
 
   @JsonProperty("PCA")
-  private OBPCAData1 PCA = null;
+  private OBPCAData1 pca = null;
 
   public OBProduct2 productName(String productName) {
     this.productName = productName;
@@ -202,8 +202,8 @@ public class OBProduct2   {
     this.otherProductType = otherProductType;
   }
 
-  public OBProduct2 BCA(OBBCAData1 BCA) {
-    this.BCA = BCA;
+  public OBProduct2 bca(OBBCAData1 bca) {
+    this.bca = bca;
     return this;
   }
 
@@ -215,16 +215,16 @@ public class OBProduct2   {
 
   @Valid
 
-  public OBBCAData1 getBCA() {
-    return BCA;
+  public OBBCAData1 getBca() {
+    return bca;
   }
 
-  public void setBCA(OBBCAData1 BCA) {
-    this.BCA = BCA;
+  public void setBca(OBBCAData1 bca) {
+    this.bca = bca;
   }
 
-  public OBProduct2 PCA(OBPCAData1 PCA) {
-    this.PCA = PCA;
+  public OBProduct2 pca(OBPCAData1 pca) {
+    this.pca = pca;
     return this;
   }
 
@@ -236,12 +236,12 @@ public class OBProduct2   {
 
   @Valid
 
-  public OBPCAData1 getPCA() {
-    return PCA;
+  public OBPCAData1 getPca() {
+    return pca;
   }
 
-  public void setPCA(OBPCAData1 PCA) {
-    this.PCA = PCA;
+  public void setPca(OBPCAData1 pca) {
+    this.pca = pca;
   }
 
 
@@ -261,13 +261,13 @@ public class OBProduct2   {
         Objects.equals(this.productType, obProduct2.productType) &&
         Objects.equals(this.marketingStateId, obProduct2.marketingStateId) &&
         Objects.equals(this.otherProductType, obProduct2.otherProductType) &&
-        Objects.equals(this.BCA, obProduct2.BCA) &&
-        Objects.equals(this.PCA, obProduct2.PCA);
+        Objects.equals(this.bca, obProduct2.bca) &&
+        Objects.equals(this.pca, obProduct2.pca);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(productName, productId, accountId, secondaryProductId, productType, marketingStateId, otherProductType, BCA, PCA);
+    return Objects.hash(productName, productId, accountId, secondaryProductId, productType, marketingStateId, otherProductType, bca, pca);
   }
 
   @Override
@@ -282,8 +282,8 @@ public class OBProduct2   {
     sb.append("    productType: ").append(toIndentedString(productType)).append("\n");
     sb.append("    marketingStateId: ").append(toIndentedString(marketingStateId)).append("\n");
     sb.append("    otherProductType: ").append(toIndentedString(otherProductType)).append("\n");
-    sb.append("    BCA: ").append(toIndentedString(BCA)).append("\n");
-    sb.append("    PCA: ").append(toIndentedString(PCA)).append("\n");
+    sb.append("    BCA: ").append(toIndentedString(bca)).append("\n");
+    sb.append("    PCA: ").append(toIndentedString(pca)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBTierBand1.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBTierBand1.java
@@ -59,7 +59,7 @@ public class OBTierBand1 {
   private OBInterestFixedVariableType1Code fixedVariableInterestRateType = null;
 
   @JsonProperty("AER")
-  private String AER = null;
+  private String aer = null;
 
   @JsonProperty("BankInterestRateType")
   private OBInterestRateType1Code bankInterestRateType = null;
@@ -223,8 +223,8 @@ public class OBTierBand1 {
     this.fixedVariableInterestRateType = fixedVariableInterestRateType;
   }
 
-  public OBTierBand1 AER(String AER) {
-    this.AER = AER;
+  public OBTierBand1 aer(String aer) {
+    this.aer = aer;
     return this;
   }
 
@@ -236,12 +236,12 @@ public class OBTierBand1 {
   @NotNull
 
 @Pattern(regexp="^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$") 
-  public String getAER() {
-    return AER;
+  public String getAer() {
+    return aer;
   }
 
-  public void setAER(String AER) {
-    this.AER = AER;
+  public void setAer(String aer) {
+    this.aer = aer;
   }
 
   public OBTierBand1 bankInterestRateType(OBInterestRateType1Code bankInterestRateType) {
@@ -392,7 +392,7 @@ public class OBTierBand1 {
         Objects.equals(this.applicationFrequency, creditInterest1TierBand.applicationFrequency) &&
         Objects.equals(this.depositInterestAppliedCoverage, creditInterest1TierBand.depositInterestAppliedCoverage) &&
         Objects.equals(this.fixedVariableInterestRateType, creditInterest1TierBand.fixedVariableInterestRateType) &&
-        Objects.equals(this.AER, creditInterest1TierBand.AER) &&
+        Objects.equals(this.aer, creditInterest1TierBand.aer) &&
         Objects.equals(this.bankInterestRateType, creditInterest1TierBand.bankInterestRateType) &&
         Objects.equals(this.bankInterestRate, creditInterest1TierBand.bankInterestRate) &&
         Objects.equals(this.notes, creditInterest1TierBand.notes) &&
@@ -403,7 +403,7 @@ public class OBTierBand1 {
 
   @Override
   public int hashCode() {
-    return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, AER, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
+    return Objects.hash(identification, tierValueMinimum, tierValueMaximum, calculationFrequency, applicationFrequency, depositInterestAppliedCoverage, fixedVariableInterestRateType, aer, bankInterestRateType, bankInterestRate, notes, otherBankInterestType, otherApplicationFrequency, otherCalculationFrequency);
   }
 
   @Override
@@ -418,7 +418,7 @@ public class OBTierBand1 {
     sb.append("    applicationFrequency: ").append(toIndentedString(applicationFrequency)).append("\n");
     sb.append("    depositInterestAppliedCoverage: ").append(toIndentedString(depositInterestAppliedCoverage)).append("\n");
     sb.append("    fixedVariableInterestRateType: ").append(toIndentedString(fixedVariableInterestRateType)).append("\n");
-    sb.append("    AER: ").append(toIndentedString(AER)).append("\n");
+    sb.append("    AER: ").append(toIndentedString(aer)).append("\n");
     sb.append("    bankInterestRateType: ").append(toIndentedString(bankInterestRateType)).append("\n");
     sb.append("    bankInterestRate: ").append(toIndentedString(bankInterestRate)).append("\n");
     sb.append("    notes: ").append(toIndentedString(notes)).append("\n");


### PR DESCRIPTION
Fixes issues: #617 #618 whereby duplicate field values appears in data responses in upper and lower case. This was happening for model objects with uppercase instance variable names despite presence of JsonProperty annotations. The field names need to be changed to lowercase and the JSonProperty annotation used to deserialize to uppercase in responses.

This is an issue with the way Jackson deserializes instance vars. Even with the **JsonProperty** annotation is still expects the field names to follow java conventions and be lowercase. See attached unit test for an example of this.

```
package com.forgerock.openbanking.aspsp.rs.store.api.openbanking.account.v2_0.products;

import com.fasterxml.jackson.annotation.JsonProperty;
import com.fasterxml.jackson.databind.ObjectMapper;
import org.junit.Test;
import uk.org.openbanking.datamodel.account.OBOtherFeesAndCharges1;
import uk.org.openbanking.datamodel.account.OBPCAData1;

public class CaseSensitiveJsonPropertiesTest {
    private static  ObjectMapper om = new ObjectMapper();

    @Test
    public void doTest() throws Exception {

        ProductWithUpperCase productUpper = new ProductWithUpperCase(new OBPCAData1().otherFeesCharges(new OBOtherFeesAndCharges1().tariffName("uc")));
        ProductWithLowerCase productLower = new ProductWithLowerCase(new OBPCAData1().otherFeesCharges(new OBOtherFeesAndCharges1().tariffName("lc")));

        System.out.println("Product with uppercase instance vars: "+om.writerWithDefaultPrettyPrinter().writeValueAsString(productUpper));
        System.out.println("Product with lowercase instance vars: "+om.writerWithDefaultPrettyPrinter().writeValueAsString(productLower));
    }

    private static class ProductWithUpperCase {
        @JsonProperty("PCA")
        private OBPCAData1 PCA;

        public ProductWithUpperCase(OBPCAData1 PCA) {
            this.PCA = PCA;
        }

        public OBPCAData1 getPCA() {
            return PCA;
        }

        public void setPCA(OBPCAData1 PCA) {
            this.PCA = PCA;
        }
    }

    private static class ProductWithLowerCase {
        @JsonProperty("PCA")
        private OBPCAData1 pca;

        public ProductWithLowerCase(OBPCAData1 pca) {
            this.pca = pca;
        }

        public OBPCAData1 getPca() {
            return pca;
        }

        public void setPca(OBPCAData1 pca) {
            this.pca = pca;
        }
    }

}
```