### PR TITLE
Adds conversion code for the Cash Account Scheme names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>joda-time</artifactId>
             <version>2.9.9</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+            <version>4.12</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountIdentification4Code.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBExternalAccountIdentification4Code.java
@@ -1,0 +1,60 @@
+/**
+ *
+ * The contents of this file are subject to the terms of the Common Development and
+ *  Distribution License (the License). You may not use this file except in compliance with the
+ *  License.
+ *
+ *  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+ *  specific language governing permission and limitations under the License.
+ *
+ *  When distributing Covered Software, include this CDDL Header Notice in each file and include
+ *  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ *  Header, with the fields enclosed by brackets [] replaced by your own identifying
+ *  information: "Portions copyright [year] [name of copyright owner]".
+ *
+ *  Copyright 2018 ForgeRock AS.
+ */
+package uk.org.openbanking.datamodel.account;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum OBExternalAccountIdentification4Code {
+
+    /** Basic Bank Account Number (BBAN) - identifier used nationally by financial institutions, ie, in individual countries, generally as part of a National Account Numbering Scheme(s), to uniquely identify the account of a customer. */
+    BBAN("UK.OBIE.BBAN"),
+
+    /** An identifier used internationally by financial institutions to uniquely identify the account of a customer at a financial institution, as described in the latest edition of the international standard ISO 13616. "Banking and related financial services - International Bank Account Number (IBAN)". */
+    IBAN("UK.OBIE.IBAN"),
+
+    /** Primary Account Number - identifier scheme used to identify a card account. */
+    PAN("UK.OBIE.PAN"),
+
+    /** Sort Code and Account Number - identifier scheme used in the UK by financial institutions to identify the account of a customer. The identifier is the concatenation of the 6 digit UK sort code and 8 digit account number.*/
+    SORTCODEACCOUNTNUMBER("UK.OBIE.SortCodeAccountNumber"),
+
+    /** Paym Scheme to make payments via mobile */
+    PAYM("UK.OBIE.Paym");
+
+    private String value;
+
+    OBExternalAccountIdentification4Code(String value) {
+        this.value = value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static OBExternalAccountIdentification4Code fromValue(String text) {
+        for (OBExternalAccountIdentification4Code b : OBExternalAccountIdentification4Code.values()) {
+            if (String.valueOf(b.value).equals(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/OBAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/OBAccountConverter.java
@@ -18,7 +18,7 @@ package uk.org.openbanking.datamodel.service.converter;
 import uk.org.openbanking.datamodel.account.*;
 import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Convert OB account data-model in different version
@@ -96,7 +96,7 @@ public class OBAccountConverter {
         if (account1.getAccount().getSecondaryIdentification() != null) {
             account2Account.secondaryIdentification(account1.getAccount().getSecondaryIdentification());
         }
-        account2.account(Arrays.asList(account2Account));
+        account2.account(Collections.singletonList(account2Account));
 
         //servicer
         if (account2.getServicer() != null) {
@@ -109,18 +109,9 @@ public class OBAccountConverter {
     }
 
     private static OBExternalAccountIdentification2Code toOBExternalAccountIdentification2Code(String obExternalAccountIdentification3Code) {
-        return OBExternalAccountIdentification2Code.valueOfReference(obExternalAccountIdentification3Code.toString());
+        return OBExternalAccountIdentification2Code.valueOfReference(obExternalAccountIdentification3Code);
     }
 
-    private static OBExternalAccountIdentification3Code toOBExternalAccountIdentification3Code(OBExternalAccountIdentification2Code obExternalAccountIdentification2Code) {
-        switch (obExternalAccountIdentification2Code) {
-            case IBAN:
-                return OBExternalAccountIdentification3Code.IBAN;
-            case SortCodeAccountNumber:
-                return OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER;
-            default:
-                return OBExternalAccountIdentification3Code.IBAN;
-        }
-    }
+
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/OBCashAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/OBCashAccountConverter.java
@@ -16,10 +16,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter;
 
-import uk.org.openbanking.datamodel.account.OBCashAccount1;
-import uk.org.openbanking.datamodel.account.OBCashAccount2;
-import uk.org.openbanking.datamodel.account.OBCashAccount3;
-import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;
+import uk.org.openbanking.datamodel.account.*;
 import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;
 
 
@@ -47,8 +44,30 @@ public class OBCashAccountConverter {
         return new OBCashAccount2()
                 .identification(cashAccount3.getIdentification())
                 .name(cashAccount3.getName())
-                .schemeName(OBExternalAccountIdentification3Code.valueOf(cashAccount3.getSchemeName()))
+                .schemeName(schemeNameToOBExternalAccountIdentification3Code(cashAccount3.getSchemeName()))
                 .secondaryIdentification(cashAccount3.getSecondaryIdentification());
+    }
+
+    private static OBExternalAccountIdentification3Code schemeNameToOBExternalAccountIdentification3Code(String schemeName) {
+        // Try OBExternalAccountIdentification4Code
+        OBExternalAccountIdentification4Code accountId4Code = OBExternalAccountIdentification4Code.fromValue(schemeName);
+        if (accountId4Code!=null) {
+            return OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(accountId4Code);
+        }
+
+        // Try OBExternalAccountIdentification3Code
+        OBExternalAccountIdentification3Code accountId3Code = OBExternalAccountIdentification3Code.fromValue(schemeName);
+        if (accountId3Code!=null) {
+            return accountId3Code;
+        }
+
+        // Try OBExternalAccountIdentification2Code
+        OBExternalAccountIdentification2Code accountId2Code = OBExternalAccountIdentification2Code.valueOfReference(schemeName);
+        if (accountId2Code!=null) {
+            return OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(accountId2Code);
+        }
+
+        return null;
     }
 
     /**
@@ -57,10 +76,11 @@ public class OBCashAccountConverter {
      * @return cash account in V3 format
      */
     public static OBCashAccount3 toOBCashAccount3(OBCashAccount1 cashAccount1) {
+        OBExternalAccountIdentification4Code code = OBExternalAccountIdentification4Code.fromValue(cashAccount1.getSchemeName().toString());
         return new OBCashAccount3()
                 .identification(cashAccount1.getIdentification())
                 .name(cashAccount1.getName())
-                .schemeName(cashAccount1.getSchemeName().toString())
+                .schemeName((code==null) ? cashAccount1.getSchemeName().toString() : code.toString())
                 .secondaryIdentification(cashAccount1.getSecondaryIdentification());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverter.java
@@ -1,0 +1,81 @@
+/**
+ *
+ * The contents of this file are subject to the terms of the Common Development and
+ *  Distribution License (the License). You may not use this file except in compliance with the
+ *  License.
+ *
+ *  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+ *  specific language governing permission and limitations under the License.
+ *
+ *  When distributing Covered Software, include this CDDL Header Notice in each file and include
+ *  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ *  Header, with the fields enclosed by brackets [] replaced by your own identifying
+ *  information: "Portions copyright [year] [name of copyright owner]".
+ *
+ *  Copyright 2018 ForgeRock AS.
+ */
+package uk.org.openbanking.datamodel.service.converter;
+
+import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;
+import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code;
+import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;
+
+public class OBExternalAccountIdentificationConverter {
+
+    public static OBExternalAccountIdentification3Code toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code obExternalAccountIdentification4Code) {
+        if (obExternalAccountIdentification4Code==null) {
+            return null;
+        }
+        switch (obExternalAccountIdentification4Code) {
+            case PAN:
+                return OBExternalAccountIdentification3Code.PAN;
+            case IBAN:
+                return OBExternalAccountIdentification3Code.IBAN;
+            case SORTCODEACCOUNTNUMBER:
+                return OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER;
+            case BBAN:
+            case PAYM:
+            default:
+                return null;
+        }
+    }
+
+    public static OBExternalAccountIdentification3Code toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code obExternalAccountIdentification2Code) {
+        if (obExternalAccountIdentification2Code==null) {
+            return null;
+        }
+        switch (obExternalAccountIdentification2Code) {
+            case SortCodeAccountNumber:
+                return OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER;
+            default:
+                return OBExternalAccountIdentification3Code.IBAN; // Existing default behaviour on 1.1
+        }
+    }
+
+    public static OBExternalAccountIdentification4Code toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code obExternalAccountIdentification3Code) {
+        if (obExternalAccountIdentification3Code==null) {
+            return null;
+        }
+        switch (obExternalAccountIdentification3Code) {
+            case SORTCODEACCOUNTNUMBER:
+                return OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER;
+            case PAN:
+                return OBExternalAccountIdentification4Code.PAN;
+            default:
+                return OBExternalAccountIdentification4Code.IBAN;
+        }
+    }
+
+    public static OBExternalAccountIdentification4Code toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code obExternalAccountIdentification2Code) {
+        if (obExternalAccountIdentification2Code==null) {
+            return null;
+        }
+        switch (obExternalAccountIdentification2Code) {
+            case SortCodeAccountNumber:
+                return OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER;
+            default:
+                return OBExternalAccountIdentification4Code.IBAN;
+        }
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverterTest.java
@@ -1,0 +1,64 @@
+package uk.org.openbanking.datamodel.service.converter;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;
+import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code;
+import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class OBExternalAccountIdentificationConverterTest {
+
+    @Test
+    public void toOBExternalAccountIdentification3_fromOBExternalAccountIdentification4Code() {
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER),
+                is(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER));
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.IBAN),
+                is(OBExternalAccountIdentification3Code.IBAN));
+
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.PAN),
+                is(OBExternalAccountIdentification3Code.PAN));
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.BBAN),
+                nullValue());
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.PAYM),
+                nullValue());
+    }
+
+    @Test
+    public void toOBExternalAccountIdentification3_fromOBExternalAccountIdentification2Code() {
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code.SortCodeAccountNumber),
+                is(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER));
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code.IBAN),
+                is(OBExternalAccountIdentification3Code.IBAN));
+    }
+
+    @Test
+    public void toOBExternalAccountIdentification4_fromOBExternalAccountIdentification2Code() {
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code.SortCodeAccountNumber),
+                is(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER));
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code.IBAN),
+                is(OBExternalAccountIdentification4Code.IBAN));
+
+    }
+
+    @Test
+    public void toOBExternalAccountIdentification4_fromOBExternalAccountIdentification3Code() {
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER),
+                is(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER));
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.IBAN),
+                is(OBExternalAccountIdentification4Code.IBAN));
+
+
+        assertThat(OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.PAN),
+                is(OBExternalAccountIdentification4Code.PAN));
+    }
+}


### PR DESCRIPTION
For task #539, updates the converter code for the Cash Account Scheme Names (aka External Account Identifiers). This is so scheme names can be converted easily between versions - especially V2.0 (enum) <-> V.3x (String).