### PR TITLE
The InstructedAmount in 1.1 is mandatory

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBInitiation1.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBInitiation1.java
@@ -109,7 +109,7 @@ public class OBInitiation1 {
    * @return instructedAmount
   **/
   @ApiModelProperty(value = "")
-
+  @NotNull
   @Valid
 
   public OBActiveOrHistoricCurrencyAndAmount getInstructedAmount() {


### PR DESCRIPTION
OB Spec (https://openbanking.atlassian.net/wiki/spaces/DZ/pages/5786479/Payment+Initiation+API+Specification+-+v1.1.0) says:

InstructedAmount | 1..1 | OBPaymentSetup1/Data/Initiation/InstructedAmount