### PR TITLE
Making supplementary and Risk more robust to potential null content

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/account/OBRisk2.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBRisk2.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 @JsonSerialize(using = OBRisk2Serializer.class)
 public class OBRisk2   {
 
-  private String data;
+  private String data = "{}";
 
   public String getData() {
     return data;

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBSupplementaryData1.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBSupplementaryData1.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 @JsonSerialize(using = OBSupplementaryData1Serializer.class)
 public class OBSupplementaryData1   {
 
-  private String data;
+  private String data = "{}";
 
   public String getData() {
     return data;

--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBSupplementaryData1.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBSupplementaryData1.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 @JsonSerialize(using = OBSupplementaryData1Serializer.class)
 public class OBSupplementaryData1   {
 
-  private String data;
+  private String data = "{}";
 
   public String getData() {
     return data;

--- a/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Deserializer.java
+++ b/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Deserializer.java
@@ -12,7 +12,7 @@
  *  Header, with the fields enclosed by brackets [] replaced by your own identifying
  *  information: "Portions copyright [year] [name of copyright owner]".
  *
- *  Copyright 2019 ForgeRock AS.
+ *  Copyright 2018 ForgeRock AS.
  */
 package uk.org.openbanking.jackson.account;
 

--- a/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Serializer.java
+++ b/src/main/java/uk/org/openbanking/jackson/account/OBRisk2Serializer.java
@@ -12,7 +12,7 @@
  *  Header, with the fields enclosed by brackets [] replaced by your own identifying
  *  information: "Portions copyright [year] [name of copyright owner]".
  *
- *  Copyright 2019 ForgeRock AS.
+ *  Copyright 2018 ForgeRock AS.
  */
 package uk.org.openbanking.jackson.account;
 

--- a/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Deserializer.java
+++ b/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Deserializer.java
@@ -12,7 +12,7 @@
  *  Header, with the fields enclosed by brackets [] replaced by your own identifying
  *  information: "Portions copyright [year] [name of copyright owner]".
  *
- *  Copyright 2019 ForgeRock AS.
+ *  Copyright 2018 ForgeRock AS.
  */
 package uk.org.openbanking.jackson.account;
 

--- a/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Serializer.java
+++ b/src/main/java/uk/org/openbanking/jackson/account/OBSupplementaryData1Serializer.java
@@ -12,7 +12,7 @@
  *  Header, with the fields enclosed by brackets [] replaced by your own identifying
  *  information: "Portions copyright [year] [name of copyright owner]".
  *
- *  Copyright 2019 ForgeRock AS.
+ *  Copyright 2018 ForgeRock AS.
  */
 package uk.org.openbanking.jackson.account;
 

--- a/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Deserializer.java
+++ b/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Deserializer.java
@@ -12,7 +12,7 @@
  *  Header, with the fields enclosed by brackets [] replaced by your own identifying
  *  information: "Portions copyright [year] [name of copyright owner]".
  *
- *  Copyright 2019 ForgeRock AS.
+ *  Copyright 2018 ForgeRock AS.
  */
 package uk.org.openbanking.jackson.payment;
 

--- a/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Serializer.java
+++ b/src/main/java/uk/org/openbanking/jackson/payment/OBSupplementaryData1Serializer.java
@@ -12,7 +12,7 @@
  *  Header, with the fields enclosed by brackets [] replaced by your own identifying
  *  information: "Portions copyright [year] [name of copyright owner]".
  *
- *  Copyright 2019 ForgeRock AS.
+ *  Copyright 2018 ForgeRock AS.
  */
 package uk.org.openbanking.jackson.payment;
 


### PR DESCRIPTION
If you create those objects in Java, you get a NPE when you deserialise them.
To make that more robust, decided to instanciate the object with an empty json.