### PR TITLE
Add validation to the amount field to match the open banking spec

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBActiveOrHistoricCurrencyAndAmount.java
@@ -19,6 +19,7 @@ package uk.org.openbanking.datamodel.payment;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import org.springframework.validation.annotation.Validated;
+import uk.org.openbanking.validation.ValidISOCurrencyCode;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -68,6 +69,7 @@ public class OBActiveOrHistoricCurrencyAndAmount   {
   **/
   @ApiModelProperty(required = true, value = "")
   @NotNull
+  @ValidISOCurrencyCode
   @Pattern(regexp="^[A-Z]{3,3}$")
   public String getCurrency() {
     return currency;

--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBActiveOrHistoricCurrencyAndAmount.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBActiveOrHistoricCurrencyAndAmount.java
@@ -48,8 +48,7 @@ public class OBActiveOrHistoricCurrencyAndAmount   {
   **/
   @ApiModelProperty(required = true, value = "")
   @NotNull
-
-
+  @Pattern(regexp="^\\d{1,13}\\.\\d{1,5}$")
   public String getAmount() {
     return amount;
   }
@@ -69,8 +68,7 @@ public class OBActiveOrHistoricCurrencyAndAmount   {
   **/
   @ApiModelProperty(required = true, value = "")
   @NotNull
-
-@Pattern(regexp="^[A-Z]{3,3}$") 
+  @Pattern(regexp="^[A-Z]{3,3}$")
   public String getCurrency() {
     return currency;
   }

--- a/src/main/java/uk/org/openbanking/validation/CurrencyCodeValidator.java
+++ b/src/main/java/uk/org/openbanking/validation/CurrencyCodeValidator.java
@@ -1,0 +1,41 @@
+/**
+ *
+ * The contents of this file are subject to the terms of the Common Development and
+ *  Distribution License (the License). You may not use this file except in compliance with the
+ *  License.
+ *
+ *  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+ *  specific language governing permission and limitations under the License.
+ *
+ *  When distributing Covered Software, include this CDDL Header Notice in each file and include
+ *  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ *  Header, with the fields enclosed by brackets [] replaced by your own identifying
+ *  information: "Portions copyright [year] [name of copyright owner]".
+ *
+ *  Copyright 2019 ForgeRock AS.
+ */
+package uk.org.openbanking.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Currency;
+
+public class CurrencyCodeValidator implements ConstraintValidator<ValidISOCurrencyCode, String> {
+    @Override
+    public void initialize(ValidISOCurrencyCode validISOCurrencyCode) {
+    }
+
+    @Override
+    public boolean isValid(String currencyCode, ConstraintValidatorContext constraintValidatorContext) {
+        if (currencyCode == null) {
+            return false;
+        }
+        try {
+            Currency.getInstance(currencyCode);
+        } catch(IllegalArgumentException e) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/validation/ValidISOCurrencyCode.java
+++ b/src/main/java/uk/org/openbanking/validation/ValidISOCurrencyCode.java
@@ -1,0 +1,41 @@
+/**
+ *
+ * The contents of this file are subject to the terms of the Common Development and
+ *  Distribution License (the License). You may not use this file except in compliance with the
+ *  License.
+ *
+ *  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+ *  specific language governing permission and limitations under the License.
+ *
+ *  When distributing Covered Software, include this CDDL Header Notice in each file and include
+ *  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ *  Header, with the fields enclosed by brackets [] replaced by your own identifying
+ *  information: "Portions copyright [year] [name of copyright owner]".
+ *
+ *  Copyright 2019 ForgeRock AS.
+ */
+package uk.org.openbanking.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = CurrencyCodeValidator.class)
+public @interface ValidISOCurrencyCode {
+    String message() default "This currency code is not a valid ISO 4217 currency code";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    boolean optional() default false;
+}

--- a/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
+++ b/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
@@ -1,0 +1,44 @@
+/**
+ *
+ * The contents of this file are subject to the terms of the Common Development and
+ *  Distribution License (the License). You may not use this file except in compliance with the
+ *  License.
+ *
+ *  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+ *  specific language governing permission and limitations under the License.
+ *
+ *  When distributing Covered Software, include this CDDL Header Notice in each file and include
+ *  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ *  Header, with the fields enclosed by brackets [] replaced by your own identifying
+ *  information: "Portions copyright [year] [name of copyright owner]".
+ *
+ *  Copyright 2019 ForgeRock AS.
+ */
+package uk.org.openbanking.validation;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class CurrencyCodeValidatorTest {
+
+    private final CurrencyCodeValidator currencyCodeValidator = new CurrencyCodeValidator();
+
+    @Test
+    public void isValid() {
+        assertThat(currencyCodeValidator.isValid("GBP", null), is(true));
+        assertThat(currencyCodeValidator.isValid("EUR", null), is(true));
+        assertThat(currencyCodeValidator.isValid("USD", null), is(true));
+        assertThat(currencyCodeValidator.isValid("TRY", null), is(true));
+        assertThat(currencyCodeValidator.isValid("XTS", null), is(true));
+
+        assertThat(currencyCodeValidator.isValid("", null), is(false));
+        assertThat(currencyCodeValidator.isValid(null, null), is(false));
+        assertThat(currencyCodeValidator.isValid("A", null), is(false));
+        assertThat(currencyCodeValidator.isValid("AB", null), is(false));
+        assertThat(currencyCodeValidator.isValid("NCC", null), is(false));
+        assertThat(currencyCodeValidator.isValid("ABCD", null), is(false));
+        assertThat(currencyCodeValidator.isValid("1234", null), is(false));
+    }
+}


### PR DESCRIPTION
Add the amount validation from the Open Banking specification so that invalid amounts will not be accepted on RS APIs