### PR TITLE
Enforce Payment context to not be null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,24 @@
             <scope>test</scope>
             <version>4.12</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <version>5.2.4.Final</version>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b08</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalPaymentContext1Code.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBExternalPaymentContext1Code.java
@@ -19,6 +19,9 @@ package uk.org.openbanking.datamodel.payment;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+
 /**
  * Specifies the payment context
  */
@@ -48,12 +51,15 @@ public enum OBExternalPaymentContext1Code {
 
   @JsonCreator
   public static OBExternalPaymentContext1Code fromValue(String text) {
+    if (text == null) {
+      return null;
+    }
     for (OBExternalPaymentContext1Code b : OBExternalPaymentContext1Code.values()) {
       if (String.valueOf(b.value).equals(text)) {
         return b;
       }
     }
-    return null;
+    throw new IllegalArgumentException("PaymentContextCode is not one of the valid values: " + OBExternalPaymentContext1Code.values());
   }
 }
 

--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBRisk1.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBRisk1.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.Objects;
 
@@ -55,9 +56,7 @@ public class OBRisk1   {
    * @return paymentContextCode
   **/
   @ApiModelProperty(value = "")
-
   @Valid
-
   public OBExternalPaymentContext1Code getPaymentContextCode() {
     return paymentContextCode;
   }

--- a/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
+++ b/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
@@ -1,0 +1,146 @@
+/**
+ *
+ * The contents of this file are subject to the terms of the Common Development and
+ *  Distribution License (the License). You may not use this file except in compliance with the
+ *  License.
+ *
+ *  You can obtain a copy of the License at https://forgerock.org/cddlv1-0/. See the License for the
+ *  specific language governing permission and limitations under the License.
+ *
+ *  When distributing Covered Software, include this CDDL Header Notice in each file and include
+ *  the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ *  Header, with the fields enclosed by brackets [] replaced by your own identifying
+ *  information: "Portions copyright [year] [name of copyright owner]".
+ *
+ *  Copyright 2019 ForgeRock AS.
+ */
+package uk.org.openbanking.jackson.payment;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import org.junit.Before;
+import org.junit.Test;
+import uk.org.openbanking.datamodel.account.OBRisk2;
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class OBRiskTest {
+
+    private ObjectMapper mapper = new ObjectMapper();
+    private Validator validator;
+
+    @Before
+    public void setUp() {
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void serialize() throws IOException {
+
+        //Given
+        String expectedValue = "{" +
+                "\"PaymentContextCode\":\"EcommerceGoods\"," +
+                "\"MerchantCategoryCode\":\"5967\"," +
+                "\"MerchantCustomerIdentification\":\"053598653254\"," +
+                "\"DeliveryAddress\":{" +
+                "\"AddressLine\":[" +
+                "\"Flat 7\"," +
+                "\"Acacia Lodge\"" +
+                "]," +
+                "\"StreetName\":\"Acacia Avenue\"," +
+                "\"BuildingNumber\":\"27\"," +
+                "\"PostCode\":\"GU31 2ZZ\"," +
+                "\"TownName\":\"Sparsholt\"," +
+                "\"CountrySubDivision\":[" +
+                "\"Wessex\"" +
+                "]," +
+                "\"Country\":\"UK\"" +
+                "}" +
+                "}";
+
+        //When
+        OBRisk1 obRisk1 = mapper.readValue(expectedValue, OBRisk1.class);
+        Set<ConstraintViolation<OBRisk1>> violations = validator.validate(obRisk1);
+        assertTrue(violations.isEmpty());
+        String resultValue = mapper.writeValueAsString(obRisk1);
+
+        //Then
+        assertThat(expectedValue, is(resultValue));
+    }
+
+    @Test
+    public void paymentContextCodeNotSpecified() throws IOException {
+
+        //Given
+        String expectedValue = "{" +
+                "\"MerchantCategoryCode\":\"5967\"," +
+                "\"MerchantCustomerIdentification\":\"053598653254\"," +
+                "\"DeliveryAddress\":{" +
+                "\"AddressLine\":[" +
+                "\"Flat 7\"," +
+                "\"Acacia Lodge\"" +
+                "]," +
+                "\"StreetName\":\"Acacia Avenue\"," +
+                "\"BuildingNumber\":\"27\"," +
+                "\"PostCode\":\"GU31 2ZZ\"," +
+                "\"TownName\":\"Sparsholt\"," +
+                "\"CountrySubDivision\":[" +
+                "\"Wessex\"" +
+                "]," +
+                "\"Country\":\"UK\"" +
+                "}" +
+                "}";
+
+        //When
+        OBRisk1 obRisk1 = mapper.readValue(expectedValue, OBRisk1.class);
+        Set<ConstraintViolation<OBRisk1>> violations = validator.validate(obRisk1);
+        assertTrue(violations.isEmpty());
+        String resultValue = mapper.writeValueAsString(obRisk1);
+
+        //Then
+        assertThat(expectedValue, is(resultValue));
+    }
+
+    @Test(expected = InvalidDefinitionException.class)
+    public void testInvalidPaymentContext() throws IOException {
+
+        //Given
+        String expectedValue = "{" +
+                "\"PaymentContextCode\":\"wrongValue\"," +
+                "\"MerchantCategoryCode\":\"5967\"," +
+                "\"MerchantCustomerIdentification\":\"053598653254\"," +
+                "\"DeliveryAddress\":{" +
+                "\"AddressLine\":[" +
+                "\"Flat 7\"," +
+                "\"Acacia Lodge\"" +
+                "]," +
+                "\"StreetName\":\"Acacia Avenue\"," +
+                "\"BuildingNumber\":\"27\"," +
+                "\"PostCode\":\"GU31 2ZZ\"," +
+                "\"TownName\":\"Sparsholt\"," +
+                "\"CountrySubDivision\":[" +
+                "\"Wessex\"" +
+                "]," +
+                "\"Country\":\"UK\"" +
+                "}" +
+                "}";
+
+        //When
+        mapper.readValue(expectedValue, OBRisk1.class);
+
+        //Then
+        //exception should be throw
+    }
+}


### PR DESCRIPTION
We got an issue in OBRI where an invalid payment context results to a 201 and a null value.

This PR make sure that Payment context code stay still optional but that an invalid value would be rejected.